### PR TITLE
Update user.js

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -668,8 +668,8 @@ apos.define('apostrophe-schemas', {
           }
           var removed = _.filter(choices, { __removed: true });
           choices = _.difference(choices, removed);
-          data[field.idsField] = _.pluck(choices, 'value');
-          data[field.removedIdsField] = _.pluck(removed, 'value');
+          data[field.idsField] = _.map(choices, 'value');
+          data[field.removedIdsField] = _.map(removed, 'value');
           if (field.relationship) {
             data[field.relationshipsField] = data[field.relationshipsField] || {};
             var relationships = data[field.relationshipsField];


### PR DESCRIPTION
_.pluck was removed as of lodash 4.0.0 and causes an error when attempting save page setting from the admin section "_.pluck is not a function". This change replaces _.pluck with the recommended _.map.